### PR TITLE
Fix: School colors and mascot (School Pride)

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,13 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="masthead">
+        <div class="mascot" aria-hidden="true">🐱</div>
+        <div class="titles">
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+      </div>
     </header>
 
     <main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -19,9 +19,29 @@ header {
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
-  background-color: #1a237e;
+  background-color: #8bc34a; /* lime green school colour */
   color: white;
   border-radius: 5px;
+}
+
+.masthead {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+
+.mascot {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: white;
+  color: #8bc34a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
 }
 
 header h1 {
@@ -54,7 +74,7 @@ section h3 {
   margin-bottom: 20px;
   padding-bottom: 10px;
   border-bottom: 1px solid #ddd;
-  color: #1a237e;
+  color: #2e7d32;
 }
 
 .activity-card {
@@ -67,7 +87,7 @@ section h3 {
 
 .activity-card h4 {
   margin-bottom: 10px;
-  color: #0066cc;
+  color: #33691e;
 }
 
 .activity-card p {
@@ -83,7 +103,7 @@ section h3 {
 
 .participants-section h5 {
   margin-bottom: 8px;
-  color: #1a237e;
+  color: #2e7d32;
   font-size: 16px;
 }
 
@@ -150,7 +170,7 @@ section h3 {
 }
 
 button {
-  background-color: #1a237e;
+  background-color: #8bc34a;
   color: white;
   border: none;
   padding: 10px 15px;
@@ -161,7 +181,7 @@ button {
 }
 
 button:hover {
-  background-color: #3949ab;
+  background-color: #7cb342;
 }
 
 .message {


### PR DESCRIPTION
Apply school branding: update accent colors to the school's lime-green palette and add a mascot to the header.

This resolves issue #2 (Missing School Pride) by replacing blue accents with the approved colors and adding a mascot element for visual identity.

Changes:
- Update `src/static/styles.css` to use lime-green accents and add mascot styles
- Add mascot markup in `src/static/index.html`

Closes #2.